### PR TITLE
Add Nothing struct to help serialization.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,10 @@ extern crate serde;
 
 use serde::{Deserialize, Serialize};
 
+pub use nothing::Nothing;
+
+mod nothing;
+
 /// HTTP request methods used in Matrix APIs.
 #[derive(Clone, Copy, Debug)]
 pub enum Method {

--- a/src/nothing.rs
+++ b/src/nothing.rs
@@ -1,0 +1,44 @@
+use serde::{Serializer, Serialize, Deserialize, Deserializer};
+
+/// A struct representing the absence of content.
+///
+/// It should be used for type parameters of the `Endpoint` trait
+/// when there is no content associated to it.
+///
+/// Contrarily to `()`, this struct has special implementations of
+/// serde traits, so that it is garanteed to be serialized as `"{}"` in JSON
+/// and `""` in url-encoding, which is required by the rest of the API.
+#[derive(Copy,Clone,Debug)]
+pub struct Nothing;
+
+impl Deserialize for Nothing {
+    fn deserialize<D>(deserializer: &mut D) -> Result<Nothing, D::Error> where D: Deserializer {
+        struct Visitor;
+        impl ::serde::de::Visitor for Visitor {
+            type Value = Nothing;
+            #[inline]
+            fn visit_seq<V>(&mut self, mut visitor: V) -> Result<Nothing, V::Error>
+                where V: ::serde::de::SeqVisitor
+            {
+                visitor.end()?;
+                Ok(Nothing{})
+            }
+            #[inline]
+            fn visit_map<V>(&mut self, mut visitor: V) -> Result<Nothing, V::Error>
+                where V: ::serde::de::MapVisitor
+            {
+                visitor.end()?;
+                Ok(Nothing{})
+            }
+        }
+        const FIELDS: &'static [&'static str] = &[];
+        deserializer.deserialize_struct("Nothing", FIELDS, Visitor)
+    }
+}
+
+impl Serialize for Nothing {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+        let state = serializer.serialize_struct("nothing", 0)?;
+        serializer.serialize_struct_end(state)
+    }
+}


### PR DESCRIPTION
This is a struct to replace the use of `()` to represent the absence of data in a `*Params` of `Response` associated type of `Endpoint`.

Contrarily to `()`, it is guaranteed to be properly serialized by serde_json and serde_urlencoded, to `"{}"` and `""` respectively. Same goes for deserialization.

The name of the struct is open for bikeshedding, I'm not entirely convinced by `Nothing` to be honest.