### PR TITLE
Yet another potential API design using generics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! # #![feature(proc_macro)]
-//! #
 //! # extern crate ruma_api;
 //! # extern crate ruma_identifiers;
 //! # #[macro_use]
@@ -27,7 +25,7 @@
 //!
 //!     /// This API endpoint's body parameters.
 //!     #[derive(Clone, Debug, Deserialize, Serialize)]
-//!     pub struct BodyParams {
+//!     pub struct Body {
 //!         pub room_id: RoomId,
 //!     }
 //!
@@ -37,41 +35,24 @@
 //!         pub room_alias: RoomAliasId,
 //!     }
 //!
+//!     pub type Request = ruma_api::request::BodyAndPathParams<Body, PathParams>;
+//!
 //!     /// Details about this API endpoint.
 //!     pub struct Endpoint;
 //!
 //!     impl ruma_api::Endpoint for Endpoint {
-//!         type BodyParams = BodyParams;
-//!         type PathParams = PathParams;
-//!         type QueryParams = ();
-//!         type Response = ();
+//!         type Request = Request;
+//!         type Response = ruma_api::response::StatusOnly;
 //!
-//!         fn method() -> ruma_api::Method {
-//!             ruma_api::Method::Put
-//!         }
-//!
-//!         fn request_path(params: Self::PathParams) -> String {
-//!             format!("/_matrix/client/r0/directory/room/{}", params.room_alias)
-//!         }
-//!
-//!         fn router_path() -> &'static str {
-//!             "/_matrix/client/r0/directory/room/:room_alias"
-//!         }
-//!
-//!         fn name() -> &'static str {
-//!             "room_directory"
-//!         }
-//!
-//!         fn description() -> &'static str {
-//!             "Matrix implementation of room directory."
-//!         }
-//!
-//!         fn requires_authentication() -> bool {
-//!             true
-//!         }
-//!
-//!         fn rate_limited() -> bool {
-//!             false
+//!         fn info() -> ruma_api::Info {
+//!             ruma_api::Info {
+//!                 description: "Matrix implementation of room directory.",
+//!                 request_method: ruma_api::Method::Put,
+//!                 name: "room_directory",
+//!                 router_path: "/_matrix/client/r0/directory/room/:room_alias",
+//!                 requires_authentication: true,
+//!                 rate_limited: false,
+//!             }
 //!         }
 //!     }
 //! }
@@ -80,8 +61,6 @@
 #![deny(missing_docs)]
 
 extern crate serde;
-
-use serde::{Deserialize, Serialize};
 
 /// HTTP request methods used in Matrix APIs.
 #[derive(Clone, Copy, Debug)]
@@ -98,37 +77,250 @@ pub enum Method {
 
 /// An API endpoint.
 pub trait Endpoint {
-    /// Request parameters supplied via the body of the HTTP request.
-    type BodyParams: Deserialize + Serialize;
+    /// The endpoint's request.
+    type Request: Request;
+    /// The endpoint's response.
+    type Response: Response;
 
-    /// Request parameters supplied via the URL's path.
-    type PathParams;
+    /// Information about the endpoint.
+    fn info() -> Info;
+}
 
-    /// Parameters supplied via the URL's query string.
-    type QueryParams: Deserialize + Serialize;
-
-    /// The body of the response.
-    type Response: Deserialize + Serialize;
-
-    /// Returns the HTTP method used by this endpoint.
-    fn method() -> Method;
-
-    /// Generates the path component of the URL for this endpoint using the supplied parameters.
-    fn request_path(params: Self::PathParams) -> String;
-
-    /// Generates a generic path component of the URL for this endpoint, suitable for `Router` from
-    /// the router crate.
-    fn router_path() -> &'static str;
-
-    /// A unique identifier for this endpoint, suitable for `Router` from the router crate.
-    fn name() -> &'static str;
-
+/// Information about an `Endpoint`.
+#[derive(Clone, Copy, Debug)]
+pub struct Info {
     /// A human-readable description of the endpoint.
-    fn description() -> &'static str;
+    pub description: &'static str,
+    /// A unique identifier for this endpoint.
+    pub name: &'static str,
+    /// Whether or not this endpoint is rate limited by the server.
+    pub rate_limited: bool,
+    /// The HTTP method used by this endpoint.
+    pub request_method: Method,
+    /// Whether or not the server requires an authenticated user for this endpoint.
+    pub requires_authentication: bool,
+    /// The path of this endpoint's URL, with variable names where path parameters should be filled
+    /// in during a request.
+    ///
+    /// This value is suitable for creating routes with `Router` from the router crate.
+    pub router_path: &'static str,
+}
 
-    /// Whether or not this endpoint requires an authenticated user.
-    fn requires_authentication() -> bool;
+/// An endpoint's request.
+pub trait Request {}
 
-    /// Whether or not this endpoint is rate limited.
-    fn rate_limited() -> bool;
+/// An endpoint's response.
+pub trait Response {}
+
+/// Implementations of the `Request` trait covering various combinations of required components
+/// among request body, headers, path parameters, and query parameters.
+pub mod request {
+    use serde::{Deserialize, Serialize};
+
+    use super::Request;
+
+    /// A request with a body, headers, path parameters, and query parameters.
+    #[derive(Debug)]
+    pub struct All<B, H, P, Q> where B: Deserialize + Serialize, Q: Deserialize + Serialize {
+        /// The request's body.
+        pub body: B,
+        /// The request's headers.
+        pub headers: H,
+        /// The request's path parameters.
+        pub path_params: P,
+        /// The request's query parameters.
+        pub query_params: Q,
+    }
+
+    /// A request with only a body.
+    #[derive(Debug)]
+    pub struct BodyOnly<B> where B: Deserialize + Serialize {
+        /// The request's body.
+        pub body: B,
+    }
+
+    /// A request with only headers.
+    #[derive(Debug)]
+    pub struct HeadersOnly<H> {
+        /// The request's headers.
+        pub headers: H,
+    }
+
+    /// A request with only path parameters.
+    #[derive(Debug)]
+    pub struct PathParamsOnly<P> {
+        /// The request's path parameters.
+        pub path_params: P,
+    }
+
+    /// A request with only query parameters.
+    #[derive(Debug)]
+    pub struct QueryParamsOnly<Q> where Q: Deserialize + Serialize {
+        /// The request's query parameters.
+        pub query_params: Q,
+    }
+
+    /// A request with no body.
+    #[derive(Debug)]
+    pub struct NoBody<H, P, Q> where Q: Deserialize + Serialize {
+        /// The request's headers.
+        pub headers: H,
+        /// The request's path parameters.
+        pub path_params: P,
+        /// The request's query parameters.
+        pub query_params: Q,
+    }
+
+    /// A request with no headers.
+    #[derive(Debug)]
+    pub struct NoHeaders<B, P, Q> where B: Deserialize + Serialize, Q: Deserialize + Serialize {
+        /// The request's body.
+        pub body: B,
+        /// The request's path parameters.
+        pub path_params: P,
+        /// The request's query parameters.
+        pub query_params: Q,
+    }
+
+    /// A request with no path parameters.
+    #[derive(Debug)]
+    pub struct NoPathParams<B, H, Q> where B: Deserialize + Serialize, Q: Deserialize + Serialize {
+        /// The request's body.
+        pub body: B,
+        /// The request's headers.
+        pub headers: H,
+        /// The request's query parameters.
+        pub query_params: Q,
+    }
+
+    /// A request with no query parameters.
+    #[derive(Debug)]
+    pub struct NoQueryParams<B, H, P> where B: Deserialize + Serialize {
+        /// The request's body.
+        pub body: B,
+        /// The request's headers.
+        pub headers: H,
+        /// The request's path parameters.
+        pub path_params: P,
+    }
+
+    /// A request with only a body and headers.
+    #[derive(Debug)]
+    pub struct BodyAndHeaders<B, H> where B: Deserialize + Serialize {
+        /// The request's body.
+        pub body: B,
+        /// The request's headers.
+        pub headers: H,
+    }
+
+    /// A request with only a body and path parameters.
+    #[derive(Debug)]
+    pub struct BodyAndPathParams<B, P> where B: Deserialize + Serialize {
+        /// The request's body.
+        pub body: B,
+        /// The request's path parameters.
+        pub path_params: P,
+    }
+
+    /// A request with only a body and query parameters.
+    #[derive(Debug)]
+    pub struct BodyAndQueryParams<B, Q>
+    where B: Deserialize + Serialize, Q: Deserialize + Serialize {
+        /// The request's body.
+        pub body: B,
+        /// The request's query parameters.
+        pub query_params: Q,
+    }
+
+    /// A request with only headers and path parameters.
+    #[derive(Debug)]
+    pub struct HeadersAndPathParams<H, P> {
+        /// The request's headers.
+        pub headers: H,
+        /// The request's path parameters.
+        pub path_params: P,
+    }
+
+    /// A request with only headers and query parameters.
+    #[derive(Debug)]
+    pub struct HeadersAndQueryParams<H, Q> where Q: Deserialize + Serialize {
+        /// The request's headers.
+        pub headers: H,
+        /// The request's query parameters.
+        pub query_params: Q,
+    }
+
+    /// A request with only path parameters and query parameters.
+    #[derive(Debug)]
+    pub struct PathParamsAndQueryParams<P, Q> where Q: Deserialize + Serialize {
+        /// The request's path parameters.
+        pub path_params: P,
+        /// The request's query parameters.
+        pub query_params: Q,
+    }
+
+    impl<B, H, P, Q> Request for All<B, H, P, Q> where B: Deserialize + Serialize, Q: Deserialize + Serialize {}
+    impl<B> Request for BodyOnly<B> where B: Deserialize + Serialize {}
+    impl<H> Request for HeadersOnly<H> {}
+    impl<P> Request for PathParamsOnly<P> {}
+    impl<Q> Request for QueryParamsOnly<Q> where Q: Deserialize + Serialize {}
+    impl<H, P, Q> Request for NoBody<H, P, Q> where Q: Deserialize + Serialize {}
+    impl<B, P, Q> Request for NoHeaders<B, P, Q> where B: Deserialize + Serialize, Q: Deserialize + Serialize {}
+    impl<B, H, Q> Request for NoPathParams<B, H, Q> where B: Deserialize + Serialize, Q: Deserialize + Serialize {}
+    impl<B, H, P> Request for NoQueryParams<B, H, P> where B: Deserialize + Serialize {}
+    impl<B, H> Request for BodyAndHeaders<B, H> where B: Deserialize + Serialize {}
+    impl<B, P> Request for BodyAndPathParams<B, P> where B: Deserialize + Serialize {}
+    impl<B, Q> Request for BodyAndQueryParams<B, Q> where B: Deserialize + Serialize, Q: Deserialize + Serialize {}
+    impl<H, P> Request for HeadersAndPathParams<H, P> {}
+    impl<H, Q> Request for HeadersAndQueryParams<H, Q> where Q: Deserialize + Serialize {}
+    impl<P, Q> Request for PathParamsAndQueryParams<P, Q> where Q: Deserialize + Serialize {}
+}
+
+/// Implementations of the `Response` trait covering various combinations of required components
+/// among request body, headers, status code.
+pub mod response {
+    use serde::{Deserialize, Serialize};
+
+    use super::Response;
+
+    /// A response with a body, headers, path parameters, and query parameters.
+    #[derive(Debug)]
+    pub struct All<B, H> where B: Deserialize + Serialize {
+        /// The response's body.
+        pub body: B,
+        /// The response's headers.
+        pub headers: H,
+        /// The response's status code.
+        pub status: u16,
+    }
+
+    /// A response with no body.
+    #[derive(Debug)]
+    pub struct NoBody<H> {
+        /// The response's headers.
+        pub headers: H,
+        /// The response's status code.
+        pub status: u16,
+    }
+
+    /// A response with no headers.
+    #[derive(Debug)]
+    pub struct NoHeaders<B> where B: Deserialize + Serialize {
+        /// The response's body.
+        pub body: B,
+        /// The response's status code.
+        pub status: u16,
+    }
+
+    /// A response with only a status code.
+    #[derive(Debug)]
+    pub struct StatusOnly {
+        /// The response's status code.
+        pub status: u16,
+    }
+
+    impl<B, H> Response for All<B, H> where B: Deserialize + Serialize {}
+    impl<H> Response for NoBody<H> {}
+    impl<B> Response for NoHeaders<B> where B: Deserialize + Serialize {}
+    impl Response for StatusOnly {}
 }


### PR DESCRIPTION
Following on from #6 and #7. This idea is an approximation of @withoutboats's [explanation of how specialization with intersecting impls](https://www.reddit.com/r/rust/comments/5o89f6/optional_associated_types/dchmew3/) would be the ideal way to design this API. Since we don't have intersecting impls, I've simply included all the possible combinations of what were previously associated types as implementations of empty `Request` and `Response` traits.

The upside is that plugging these structs in can be done with just a type alias, and that we don't need to implement custom serialization for a `Nothing`/`Unused` type, and we don't need to use the `!` type.

The downside is that having all these extra structs fields kind of unwieldy, but perhaps not that different other places in Rust where a less than ideal API is used in the absence of a feature we know will arrive some day in the future. Iterators in the standard library having concrete return types like `Filter` and `Map` in the absence of stable impl Trait comes to mind as an example.

One thing I've punted on for now, pending feedback on whether it's even worth it to proceed: HTTP headers are just a generic `H` type with no constraints. More information would have to be conveyed for them to be useful.

This design also shares the downside with #7 of not having my ideal `Response` API, with each potential status code having its own set of headers and its own struct for the response body.

Thoughts?

/cc @Ralith @vberger @eternaleye @jplatte @exul @neosam