### PR TITLE
Revision of the API based on Ralith's ideas.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.3.0"
 [dependencies]
 
 [dev-dependencies]
-ruma-identifiers = "0.7"
+ruma-identifiers = "0.8"
 serde = "0.9"
 serde_derive = "0.9"
 serde_json = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ repository = "https://github.com/ruma/ruma-api"
 version = "0.3.0"
 
 [dependencies]
-serde = "0.8.21"
 
 [dev-dependencies]
-ruma-identifiers = "0.6.0"
-serde_derive = "0.8.21"
+ruma-identifiers = "0.7"
+serde = "0.9"
+serde_derive = "0.9"
+serde_json = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ pub struct Request {
     /// The request body.
     pub body: Vec<u8>,
     /// The HTTP request headers.
-    pub headers: Vec<(Vec<u8>, Vec<u8>)>,
+    pub headers: Vec<(String, Vec<u8>)>,
     /// The HTTP request method.
     pub method: Method,
     /// The path component of the request's URL.
@@ -217,7 +217,7 @@ pub struct Response {
     /// The request body.
     pub body: Vec<u8>,
     /// The HTTP request headers.
-    pub headers: Vec<(Vec<u8>, Vec<u8>)>,
+    pub headers: Vec<(String, Vec<u8>)>,
     /// The HTTP status code.
     pub status: u16,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,9 @@
 //!     use serde_json::{Error as SerdeJsonError, from_slice, to_vec};
 //!
 //!     // This macro defines a public type `Endpoint` and implements `ruma_api::Endpoint`
-//!     // for it with the provided details.
+//!     // for it with the provided details. It expects types named `Request` and `Response` in the
+//!     // local scope to use for the associated types of the same name.
 //!     endpoint! {
-//!         type Request = Request;
-//!         type Response = Response;
-//!
 //!         description: "Add an alias to a room.",
 //!         name: "create_alias",
 //!         rate_limited: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub struct Info {
 }
 
 /// HTTP request methods used in Matrix APIs.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Method {
     /// DELETE
     Delete,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,10 @@
 //!
 //! ```rust,no_run
 //! # #![feature(try_from)]
-//! # extern crate ruma_api;
+//! # #[macro_use] extern crate ruma_api;
 //! # extern crate ruma_identifiers;
 //! # extern crate serde;
-//! # #[macro_use]
-//! # extern crate serde_derive;
+//! # #[macro_use] extern crate serde_derive;
 //! # extern crate serde_json;
 //! #
 //! # fn main() {
@@ -24,8 +23,19 @@
 //!     use ruma_identifiers::{Error as RumaIdentifiersError, RoomAliasId, RoomId};
 //!     use serde_json::{Error as SerdeJsonError, from_slice, to_vec};
 //!
-//!     /// Endpoint for adding an alias to a room.
-//!     pub struct Endpoint;
+//!     // This macro defines a public type `Endpoint` and implements `ruma_api::Endpoint`
+//!     // for it with the provided details.
+//!     endpoint! {
+//!         type Request = Request;
+//!         type Response = Response;
+//!
+//!         description: "Add an alias to a room.",
+//!         name: "create_alias",
+//!         rate_limited: false,
+//!         request_method: Put,
+//!         requires_authentication: true,
+//!         router_path: "/_matrix/client/r0/directory/room/:room_alias"
+//!     }
 //!
 //!     /// An error when converting between `Request`/`Response` and
 //!     /// `ruma_api::Request`/`ruma_api::Response`.
@@ -52,22 +62,6 @@
 //!
 //!     /// The response from this endpoint.
 //!     pub struct Response;
-//!
-//!     impl ruma_api::Endpoint for Endpoint {
-//!         type Request = Request;
-//!         type Response = Response;
-//!
-//!         fn info() -> Info {
-//!             Info {
-//!                 description: "Add an alias to a room.",
-//!                 name: "create_alias",
-//!                 rate_limited: false,
-//!                 request_method: Method::Put,
-//!                 requires_authentication: true,
-//!                 router_path: "/_matrix/client/r0/directory/room/:room_alias",
-//!             }
-//!         }
-//!     }
 //!
 //!     impl Into<ruma_api::Request> for Request {
 //!         fn into(self) -> ruma_api::Request {
@@ -134,6 +128,8 @@
 #![deny(missing_docs)]
 
 use std::convert::TryFrom;
+
+mod macros;
 
 /// Information about an `Endpoint`.
 #[derive(Clone, Copy, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 //!                 headers: Vec::new(),
 //!                 method: Endpoint::info().request_method,
 //!                 path: format!("/_matrix/client/r0/directory/room/{}", self.room_alias),
-//!                 query: Vec::new(),
+//!                 query: None,
 //!             }
 //!         }
 //!     }
@@ -201,7 +201,7 @@ pub struct Request {
     /// The path component of the request's URL.
     pub path: String,
     /// The query string component of the request's URL.
-    pub query: Vec<(String, String)>
+    pub query: Option<String>,
 }
 
 /// An HTTP response.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,87 +1,117 @@
 //! Crate ruma_api contains core types used to define the requests and responses for each endpoint
 //! in the various [Matrix](https://matrix.org) API specifications.
 //! These types can be shared by client and server code for all Matrix APIs.
-//!
-//! When implementing a new Matrix API, each endpoint have a type that implements `Endpoint`, plus
-//! any necessary associated types.
-//! An implementation of `Endpoint` contains all the information about the HTTP method, the path and
-//! input parameters for requests, and the structure of a successful response.
-//! Such types can then be used by client code to make requests, and by server code to fulfill
-//! those requests.
+//!  When implementing a new Matrix API, each endpoint should have a type that implements `Endpoint`,
+//! plus the associated `Request` and `Response` types.
 //!
 //! # Example
 //!
 //! ```rust,no_run
-//! # #![feature(proc_macro)]
-//! #
+//! # #![feature(try_from)]
 //! # extern crate ruma_api;
 //! # extern crate ruma_identifiers;
+//! # extern crate serde;
 //! # #[macro_use]
 //! # extern crate serde_derive;
+//! # extern crate serde_json;
 //! #
 //! # fn main() {
 //! /// PUT /_matrix/client/r0/directory/room/:room_alias
 //! pub mod create {
-//!     use ruma_api;
-//!     use ruma_identifiers::{RoomAliasId, RoomId};
+//!     use std::convert::TryFrom;
 //!
-//!     /// This API endpoint's body parameters.
-//!     #[derive(Clone, Debug, Deserialize, Serialize)]
-//!     pub struct BodyParams {
+//!     use ruma_api::{self, Info, Method};
+//!     use ruma_identifiers::{RoomAliasId, RoomId};
+//!     use serde_json::to_vec;
+//!
+//!     /// Endpoint for adding an alias to a room.
+//!     pub struct Endpoint;
+//!
+//!     /// Input parameters for a request to this endpoint.
+//!     pub struct Request {
+//!         pub room_alias: RoomAliasId,
 //!         pub room_id: RoomId,
 //!     }
 //!
-//!     /// This API endpoint's path parameters.
-//!     #[derive(Clone, Debug)]
-//!     pub struct PathParams {
-//!         pub room_alias: RoomAliasId,
+//!     #[derive(Serialize)]
+//!     struct RequestBody {
+//!         pub room_id: RoomId,
 //!     }
 //!
-//!     /// Details about this API endpoint.
-//!     pub struct Endpoint;
+//!     /// The response from this endpoint.
+//!     pub struct Response;
 //!
 //!     impl ruma_api::Endpoint for Endpoint {
-//!         type BodyParams = BodyParams;
-//!         type PathParams = PathParams;
-//!         type QueryParams = ();
-//!         type Response = ();
+//!         type Request = Request;
+//!         type Response = Response;
 //!
-//!         fn method() -> ruma_api::Method {
-//!             ruma_api::Method::Put
+//!         fn info() -> &'static Info {
+//!             &Info {
+//!                 description: "Add an alias to a room.",
+//!                 name: "create_alias",
+//!                 rate_limited: false,
+//!                 request_method: Method::Put,
+//!                 requires_authentication: true,
+//!                 router_path: "/_matrix/client/r0/directory/room/:room_alias",
+//!             }
 //!         }
+//!     }
 //!
-//!         fn request_path(params: Self::PathParams) -> String {
-//!             format!("/_matrix/client/r0/directory/room/{}", params.room_alias)
-//!         }
+//!     impl Into<ruma_api::Request> for Request {
+//!         fn into(self) -> ruma_api::Request {
+//!             let request_body = RequestBody {
+//!                 room_id: self.room_id,
+//!             };
 //!
-//!         fn router_path() -> &'static str {
-//!             "/_matrix/client/r0/directory/room/:room_alias"
+//!             ruma_api::Request {
+//!                 body: to_vec(&request_body).expect("request body should serialize"),
+//!                 headers: Vec::new(),
+//!                 method: Endpoint::info().request_method,
+//!                 path: format!("/_matrix/client/r0/directory/room/{}", self.room_alias),
+//!                 query: Vec::new(),
+//!             }
 //!         }
+//!     }
 //!
-//!         fn name() -> &'static str {
-//!             "room_directory"
-//!         }
+//!     impl TryFrom<ruma_api::Request> for Request {
+//!         // TODO
+//!     }
 //!
-//!         fn description() -> &'static str {
-//!             "Matrix implementation of room directory."
-//!         }
+//!     impl Into<ruma_api::Response> for Response {
+//!         Response
+//!     }
 //!
-//!         fn requires_authentication() -> bool {
-//!             true
-//!         }
-//!
-//!         fn rate_limited() -> bool {
-//!             false
-//!         }
+//!     impl TryFrom<ruma_api::Response> for Response {
+//!         // TODO
 //!     }
 //! }
 //! # }
 
+#![feature(try_from)]
+#![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 
-extern crate serde;
+use std::convert::TryFrom;
 
-use serde::{Deserialize, Serialize};
+/// Information about an `Endpoint`.
+#[derive(Clone, Copy, Debug)]
+pub struct Info {
+    /// A human-readable description of the endpoint.
+    pub description: &'static str,
+    /// A unique identifier for this endpoint.
+    pub name: &'static str,
+    /// Whether or not this endpoint is rate limited by the server.
+    pub rate_limited: bool,
+    /// The HTTP method used by this endpoint.
+    pub request_method: Method,
+    /// Whether or not the server requires an authenticated user for this endpoint.
+    pub requires_authentication: bool,
+    /// The path of this endpoint's URL, with variable names where path parameters should be filled
+    /// in during a request.
+    ///
+    /// This value is suitable for creating routes with `Router` from the router crate.
+    pub router_path: &'static str,
+}
 
 /// HTTP request methods used in Matrix APIs.
 #[derive(Clone, Copy, Debug)]
@@ -98,37 +128,52 @@ pub enum Method {
 
 /// An API endpoint.
 pub trait Endpoint {
-    /// Request parameters supplied via the body of the HTTP request.
-    type BodyParams: Deserialize + Serialize;
+    /// Request data from the client.
+    type Request: Into<Request> + TryFrom<Request>;
 
-    /// Request parameters supplied via the URL's path.
-    type PathParams;
+    /// Response data from the server.
+    type Response: Into<Response> + TryFrom<Response>;
 
-    /// Parameters supplied via the URL's query string.
-    type QueryParams: Deserialize + Serialize;
+    /// General information about the endpoint.
+    fn info() -> &'static Info;
+}
 
-    /// The body of the response.
-    type Response: Deserialize + Serialize;
+/// An HTTP request.
+///
+/// This structure is intentionally abstract so as not to bind `ruma-api` to any particular HTTP
+/// library.
+/// A library implementing `Endpoint`s must provide conversions between their own request types and
+/// `Request`.
+/// Programs consuming such a Matrix API library should then provide conversions between their HTTP
+/// library of choice and `Request`.
+#[derive(Clone, Debug)]
+pub struct Request {
+    /// The request body.
+    pub body: Vec<u8>,
+    /// The HTTP request headers.
+    pub headers: Vec<(Vec<u8>, Vec<u8>)>,
+    /// The HTTP request method.
+    pub method: Method,
+    /// The path component of the request's URL.
+    pub path: String,
+    /// The query string component of the request's URL.
+    pub query: Vec<(String, String)>
+}
 
-    /// Returns the HTTP method used by this endpoint.
-    fn method() -> Method;
-
-    /// Generates the path component of the URL for this endpoint using the supplied parameters.
-    fn request_path(params: Self::PathParams) -> String;
-
-    /// Generates a generic path component of the URL for this endpoint, suitable for `Router` from
-    /// the router crate.
-    fn router_path() -> &'static str;
-
-    /// A unique identifier for this endpoint, suitable for `Router` from the router crate.
-    fn name() -> &'static str;
-
-    /// A human-readable description of the endpoint.
-    fn description() -> &'static str;
-
-    /// Whether or not this endpoint requires an authenticated user.
-    fn requires_authentication() -> bool;
-
-    /// Whether or not this endpoint is rate limited.
-    fn rate_limited() -> bool;
+/// An HTTP response.
+///
+/// This structure is intentionally abstract so as not to bind `ruma-api` to any particular HTTP
+/// library.
+/// A library implementing `Endpoint`s must provide conversions between their own response types and
+/// `Request`.
+/// Programs consuming such a Matrix API library should then provide conversions between their HTTP
+/// library of choice and `Response`.
+#[derive(Clone, Debug)]
+pub struct Response {
+    /// The request body.
+    pub body: Vec<u8>,
+    /// The HTTP request headers.
+    pub headers: Vec<(Vec<u8>, Vec<u8>)>,
+    /// The HTTP status code.
+    pub status: u16,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Crate ruma_api contains core types used to define the requests and responses for each endpoint
 //! in the various [Matrix](https://matrix.org) API specifications.
 //! These types can be shared by client and server code for all Matrix APIs.
-//!  When implementing a new Matrix API, each endpoint should have a type that implements `Endpoint`,
+//! When implementing a new Matrix API, each endpoint should have a type that implements `Endpoint`,
 //! plus the associated `Request` and `Response` types.
 //!
 //! # Example
@@ -53,21 +53,19 @@
 //!     /// The response from this endpoint.
 //!     pub struct Response;
 //!
-//!     static INFO: Info = Info {
-//!         description: "Add an alias to a room.",
-//!         name: "create_alias",
-//!         rate_limited: false,
-//!         request_method: Method::Put,
-//!         requires_authentication: true,
-//!         router_path: "/_matrix/client/r0/directory/room/:room_alias",
-//!     };
-//!
 //!     impl ruma_api::Endpoint for Endpoint {
 //!         type Request = Request;
 //!         type Response = Response;
 //!
-//!         fn info() -> &'static Info {
-//!             &INFO
+//!         fn info() -> Info {
+//!             Info {
+//!                 description: "Add an alias to a room.",
+//!                 name: "create_alias",
+//!                 rate_limited: false,
+//!                 request_method: Method::Put,
+//!                 requires_authentication: true,
+//!                 router_path: "/_matrix/client/r0/directory/room/:room_alias",
+//!             }
 //!         }
 //!     }
 //!
@@ -181,7 +179,7 @@ pub trait Endpoint {
     type Response: Into<Response> + TryFrom<Response>;
 
     /// General information about the endpoint.
-    fn info() -> &'static Info;
+    fn info() -> Info;
 }
 
 /// An HTTP request.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@
 //!             };
 //!
 //!             ruma_api::Request {
-//!                 body: to_vec(&request_body).expect("request body should serialize"),
-//!                 headers: Vec::new(),
+//!                 body: Some(to_vec(&request_body).expect("request body should serialize")),
+//!                 headers: None,
 //!                 method: Endpoint::info().request_method,
 //!                 path: format!("/_matrix/client/r0/directory/room/{}", self.room_alias),
 //!                 query: None,
@@ -90,7 +90,9 @@
 //!
 //!         fn try_from(request: ruma_api::Request) -> Result<Self, Self::Err> {
 //!             let parts: Vec<&str> = request.path.split('/').collect();
-//!             let request_body: RequestBody = from_slice(&request.body)?;
+//!             let request_body: RequestBody = from_slice(
+//!                 &request.body.expect("body should be present")
+//!             )?;
 //!
 //!             Ok(Request {
 //!                 room_alias: RoomAliasId::try_from(parts[6])?,
@@ -101,11 +103,7 @@
 //!
 //!     impl Into<ruma_api::Response> for Response {
 //!         fn into(self) -> ruma_api::Response {
-//!             ruma_api::Response {
-//!                 body: Vec::new(),
-//!                 headers: Vec::new(),
-//!                 status: 200,
-//!             }
+//!             ruma_api::Response::default()
 //!         }
 //!     }
 //!
@@ -193,9 +191,9 @@ pub trait Endpoint {
 #[derive(Clone, Debug)]
 pub struct Request {
     /// The request body.
-    pub body: Vec<u8>,
+    pub body: Option<Vec<u8>>,
     /// The HTTP request headers.
-    pub headers: Vec<(String, Vec<u8>)>,
+    pub headers: Option<Vec<(String, Vec<u8>)>>,
     /// The HTTP request method.
     pub method: Method,
     /// The path component of the request's URL.
@@ -215,9 +213,20 @@ pub struct Request {
 #[derive(Clone, Debug)]
 pub struct Response {
     /// The request body.
-    pub body: Vec<u8>,
+    pub body: Option<Vec<u8>>,
     /// The HTTP request headers.
-    pub headers: Vec<(String, Vec<u8>)>,
+    pub headers: Option<Vec<(String, Vec<u8>)>>,
     /// The HTTP status code.
     pub status: u16,
+}
+
+impl Default for Response {
+    /// Returns a `Response` with status code 200, but no body or headers.
+    fn default() -> Self {
+        Response {
+            body: None,
+            headers: None,
+            status: 200,
+        }
+    }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,9 +2,6 @@
 #[macro_export]
 macro_rules! endpoint {
     (
-        type Request = $request:ty;
-        type Response = $response:ty;
-
         description: $description:expr,
         name: $name:expr,
         rate_limited: $rate_limited:expr,
@@ -17,8 +14,8 @@ macro_rules! endpoint {
         pub struct Endpoint;
 
         impl $crate::Endpoint for Endpoint {
-            type Request = $request;
-            type Response = $response;
+            type Request = Request;
+            type Response = Response;
 
             fn info() -> $crate::Info {
                 $crate::Info {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,35 @@
+/// Convenience macro for quickly creating an API endpoint.
+#[macro_export]
+macro_rules! endpoint {
+    (
+        type Request = $request:ty;
+        type Response = $response:ty;
+
+        description: $description:expr,
+        name: $name:expr,
+        rate_limited: $rate_limited:expr,
+        request_method: $request_method:ident,
+        requires_authentication: $requires_authentication:expr,
+        router_path: $router_path:expr
+    ) => {
+        #[doc=$description]
+        #[derive(Clone, Copy, Debug)]
+        pub struct Endpoint;
+
+        impl $crate::Endpoint for Endpoint {
+            type Request = $request;
+            type Response = $response;
+
+            fn info() -> $crate::Info {
+                $crate::Info {
+                    description: $description,
+                    name: $name,
+                    rate_limited: $rate_limited,
+                    request_method: $crate::Method::$request_method,
+                    requires_authentication: $requires_authentication,
+                    router_path: $router_path,
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Supercedes #6.

I talked with @Ralith some more tonight and the idea he's been trying to explain finally clicked. The key that I wasn't getting before is that ruma-api would be used by _both_ ruma-client-api and ruma/ruma-client. Using this approach, ruma-api is still agnostic to any particular HTTP library, but ruma-client-api can still have a general concept of the components of a request.

Instead of the dependency graph looking like this:

```
ruma/ruma-client
       |
       V
ruma-client-api
       |
       V
   ruma-api
```

It would look like this:

```
ruma/ruma-client
  |    |
  |    V
  |  ruma-client-api
  |    |
  V    V
 ruma-api
```

ruma-api provides the `Endpoint` trait which has only two associated types: a request and a response. It also provides two structs, `Request` and `Response`, which are abstract representations of an HTTP request and response, not coupled to any HTTP library. `Endpoint` requires that its request and response implement conversions between their own types and these abstract types provided by ruma-api.

ruma-client-api implements `Endpoint` for all the endpoints in the client-server API. For each endpoint, it provides a single request struct and a single response struct as its public interface, so that consumers don't need to care about which part of the HTTP request or response a piece of data goes in. It then provides conversions between these two types, and ruma-api's abstract `Request` and `Response`.

ruma and ruma-client simply bind ruma-client-api with iron and hyper, respectively, by providing another set of conversions between iron/hyper's request/response and ruma-api's abstract `Request` and `Response`.

I haven't finished spiking this out, as you can see from the TODO comments and failing build, but I wanted to share and get some feedback and perhaps some advice for the remaining implementation.

Converting `ruma_api::Request` back into the concrete request type in the example in the docs feels awkward. In ruma, we use the router crate, which handles extracting the path parameters. I'm not sure how to get the path parameter in the implementation of `TryFrom<ruma_api::Request> for Request` in the example because we don't have that router middleware as input.

I'm also not sure what the associated `Error` type should be for the two `TryFrom` implementations.

/cc @Ralith @vberger @eternaleye @jplatte @exul @neosam