### PR TITLE
Bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,9 @@ repository = "https://github.com/ruma/ruma-api"
 version = "0.3.0"
 
 [dependencies]
-futures = "0.1.13"
+futures = "0.1.14"
+hyper = "0.11"
 serde_json = "1.0.2"
-
-[dependencies.hyper]
-git = "https://github.com/hyperium/hyper"
-rev = "fed04dfb58e19b408322d4e5ca7474871e848a35"
 
 [dev-dependencies]
 ruma-identifiers = "0.11"


### PR DESCRIPTION
Hyper 0.11 has been released, update ruma-api to use it.