### PR TITLE
Fix serde attributes not being stripped

### DIFF
--- a/ruma-api-macros/src/api.rs
+++ b/ruma-api-macros/src/api.rs
@@ -20,7 +20,7 @@ use self::{metadata::Metadata, request::Request, response::Response};
 /// Removes `serde` attributes from struct fields.
 pub fn strip_serde_attrs(field: &Field) -> Field {
     let mut field = field.clone();
-    field.attrs.retain(|attr| attr.path.is_ident("serde"));
+    field.attrs.retain(|attr| !attr.path.is_ident("serde"));
     field
 }
 


### PR DESCRIPTION
A recent change caused the logic in strip_serde_attrs to be inverted, stripping only attributes that aren't "serde". Add a "!" to properly fit with the use of retain().