### PR TITLE
Implement #[ruma_api(raw_body)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,11 +198,9 @@ use serde_urlencoded;
 ///
 /// ## Fallible deserialization
 ///
-/// All request and response types also derive [`Outgoing`][]. As such, to allow fallible
+/// All request and response types also derive [`Outgoing`][Outgoing]. As such, to allow fallible
 /// deserialization, you can use the `#[wrap_incoming]` attribute. For details, see the
-/// documentation for [`Outgoing`][].
-///
-/// [`Outgoing`]: derive.Outgoing.html
+/// documentation for [the derive macro](derive.Outgoing.html).
 // TODO: Explain the concept of fallible deserialization before jumping to `ruma_api::Outgoing`
 #[cfg(feature = "with-ruma-api-macros")]
 pub use ruma_api_macros::ruma_api;

--- a/tests/ruma_api_macros.rs
+++ b/tests/ruma_api_macros.rs
@@ -86,12 +86,42 @@ pub mod newtype_body_endpoint {
 
         request {
             #[ruma_api(body)]
-            pub file: Vec<u8>,
+            pub list_of_custom_things: Vec<MyCustomType>,
         }
 
         response {
             #[ruma_api(body)]
-            pub my_custom_type: MyCustomType,
+            pub my_custom_thing: MyCustomType,
+        }
+    }
+}
+
+pub mod newtype_raw_body_endpoint {
+    use ruma_api_macros::ruma_api;
+
+    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+    pub struct MyCustomType {
+        pub foo: String,
+    }
+
+    ruma_api! {
+        metadata {
+            description: "Does something.",
+            method: PUT,
+            name: "newtype_body_endpoint",
+            path: "/_matrix/some/newtype/body/endpoint",
+            rate_limited: false,
+            requires_authentication: false,
+        }
+
+        request {
+            #[ruma_api(raw_body)]
+            pub file: Vec<u8>,
+        }
+
+        response {
+            #[ruma_api(raw_body)]
+            pub file: Vec<u8>,
         }
     }
 }


### PR DESCRIPTION
This PR implements a new `ruma_api` attribute, `raw_body`, which bypasses (de)serialization for `Vec<u8>` fields that represent the body of an HTTP request / response verbatim. It is a prerequisite for fixing https://github.com/ruma/ruma-client-api/issues/81.

I'm not very satisfied with the implementation, however. It doesn't complicate things that much, but partially reverts past simplifications (always having a `RequestBody` and `ResponseBody` type) and showed me just how different the request and response macro code are (and not because the input or output is that different).