### PR TITLE
Emit error when encounter non-UTF8 characters after percent-decoding path segment

### DIFF
--- a/ruma-api-macros/src/api.rs
+++ b/ruma-api-macros/src/api.rs
@@ -151,9 +151,16 @@ impl ToTokens for Api {
                             use ruma_api::error::RequestDeserializationError;
 
                             let segment = path_segments.get(#i).unwrap().as_bytes();
-                            let decoded =
-                                ruma_api::exports::percent_encoding::percent_decode(segment)
-                                .decode_utf8_lossy();
+                            let decoded = match ruma_api::exports::percent_encoding::percent_decode(
+                                segment
+                            ).decode_utf8() {
+                                Ok(x) => x,
+                                Err(err) => {
+                                    return Err(
+                                        RequestDeserializationError::new(err, request).into()
+                                    );
+                                }
+                            };
                             match std::convert::TryFrom::try_from(decoded.deref()) {
                                 Ok(val) => val,
                                 Err(err) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -191,7 +191,7 @@ enum SerializationError {
 #[doc(hidden)]
 #[derive(Debug)]
 pub enum DeserializationError {
-    Encod(std::str::Utf8Error),
+    Utf8(std::str::Utf8Error),
     Json(serde_json::Error),
     Query(serde_urlencoded::de::Error),
     Ident(ruma_identifiers::Error),
@@ -203,7 +203,7 @@ pub enum DeserializationError {
 impl Display for DeserializationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            DeserializationError::Encod(err) => Display::fmt(err, f),
+            DeserializationError::Utf8(err) => Display::fmt(err, f),
             DeserializationError::Json(err) => Display::fmt(err, f),
             DeserializationError::Query(err) => Display::fmt(err, f),
             DeserializationError::Ident(err) => Display::fmt(err, f),
@@ -215,7 +215,7 @@ impl Display for DeserializationError {
 #[doc(hidden)]
 impl From<std::str::Utf8Error> for DeserializationError {
     fn from(err: std::str::Utf8Error) -> Self {
-        Self::Encod(err)
+        Self::Utf8(err)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -191,6 +191,7 @@ enum SerializationError {
 #[doc(hidden)]
 #[derive(Debug)]
 pub enum DeserializationError {
+    Encod(std::str::Utf8Error),
     Json(serde_json::Error),
     Query(serde_urlencoded::de::Error),
     Ident(ruma_identifiers::Error),
@@ -202,11 +203,19 @@ pub enum DeserializationError {
 impl Display for DeserializationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
+            DeserializationError::Encod(err) => Display::fmt(err, f),
             DeserializationError::Json(err) => Display::fmt(err, f),
             DeserializationError::Query(err) => Display::fmt(err, f),
             DeserializationError::Ident(err) => Display::fmt(err, f),
             DeserializationError::Strum(err) => Display::fmt(err, f),
         }
+    }
+}
+
+#[doc(hidden)]
+impl From<std::str::Utf8Error> for DeserializationError {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Self::Encod(err)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,13 @@ mod tests {
                     room_id: request_body.room_id,
                     room_alias: {
                         let segment = path_segments.get(5).unwrap().as_bytes();
-                        let decoded = percent_encoding::percent_decode(segment).decode_utf8_lossy();
+                        let decoded = match percent_encoding::percent_decode(segment).decode_utf8()
+                        {
+                            Ok(x) => x,
+                            Err(err) => {
+                                return Err(RequestDeserializationError::new(err, request).into())
+                            }
+                        };
                         match serde_json::from_str(decoded.deref()) {
                             Ok(id) => id,
                             Err(err) => {


### PR DESCRIPTION
This PR let the code emit error when encounter with non-UTF8 characters after percent-decoding the path segment.

Closes #43