### PR TITLE
Migrate to ruma-serde from serde_urlencoded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ http = "0.2.1"
 percent-encoding = "2.1.0"
 ruma-api-macros = { version = "=0.16.0-rc.3", path = "ruma-api-macros" }
 ruma-identifiers = "0.16.0"
-ruma-serde = "0.1.0"
+ruma-serde = "0.1.3"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.51"
 strum = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ http = "0.2.1"
 percent-encoding = "2.1.0"
 ruma-api-macros = { version = "=0.16.0-rc.3", path = "ruma-api-macros" }
 ruma-identifiers = "0.16.0"
+ruma-serde = "0.1.0"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.51"
-serde_urlencoded = "0.6.1"
 strum = "0.18.0"
 
 [dev-dependencies]

--- a/ruma-api-macros/src/api.rs
+++ b/ruma-api-macros/src/api.rs
@@ -204,7 +204,7 @@ impl ToTokens for Api {
                 // error when the type of the field with the query_map
                 // attribute doesn't implement IntoIterator<Item = (String, String)>
                 //
-                // This is necessary because the serde_urlencoded::to_string
+                // This is necessary because the ruma_serde::urlencoded::to_string
                 // call will result in a runtime error when the type cannot be
                 // encoded as a list key-value pairs (?key1=value1&key2=value2)
                 //
@@ -217,7 +217,7 @@ impl ToTokens for Api {
                 assert_trait_impl::<#field_type>();
 
                 let request_query = RequestQuery(request.#field_name);
-                format!("?{}", ruma_api::exports::serde_urlencoded::to_string(request_query)?)
+                format!("?{}", ruma_api::exports::ruma_serde::urlencoded::to_string(request_query)?)
             })
         } else if self.request.has_query_fields() {
             let request_query_init_fields = self.request.request_query_init_fields();
@@ -227,7 +227,7 @@ impl ToTokens for Api {
                     #request_query_init_fields
                 };
 
-                format!("?{}", ruma_api::exports::serde_urlencoded::to_string(request_query)?)
+                format!("?{}", ruma_api::exports::ruma_serde::urlencoded::to_string(request_query)?)
             })
         } else {
             quote! {
@@ -237,7 +237,7 @@ impl ToTokens for Api {
 
         let extract_request_query = if self.request.query_map_field().is_some() {
             quote! {
-                let request_query = match ruma_api::exports::serde_urlencoded::from_str(
+                let request_query = match ruma_api::exports::ruma_serde::urlencoded::from_str(
                     &request.uri().query().unwrap_or("")
                 ) {
                     Ok(query) => query,
@@ -251,7 +251,7 @@ impl ToTokens for Api {
         } else if self.request.has_query_fields() {
             quote! {
                 let request_query: RequestQuery =
-                    match ruma_api::exports::serde_urlencoded::from_str(
+                    match ruma_api::exports::ruma_serde::urlencoded::from_str(
                         &request.uri().query().unwrap_or("")
                     ) {
                         Ok(query) => query,

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,8 +29,8 @@ impl From<serde_json::Error> for IntoHttpError {
 }
 
 #[doc(hidden)]
-impl From<serde_urlencoded::ser::Error> for IntoHttpError {
-    fn from(err: serde_urlencoded::ser::Error) -> Self {
+impl From<ruma_serde::urlencoded::error::Error> for IntoHttpError {
+    fn from(err: ruma_serde::urlencoded::error::Error) -> Self {
         Self(SerializationError::Query(err))
     }
 }
@@ -195,7 +195,7 @@ impl<E: std::error::Error> std::error::Error for ServerError<E> {}
 #[derive(Debug)]
 enum SerializationError {
     Json(serde_json::Error),
-    Query(serde_urlencoded::ser::Error),
+    Query(ruma_serde::urlencoded::error::Error),
 }
 
 /// This type is public so it is accessible from `ruma_api!` generated code.
@@ -205,7 +205,7 @@ enum SerializationError {
 pub enum DeserializationError {
     Utf8(std::str::Utf8Error),
     Json(serde_json::Error),
-    Query(serde_urlencoded::de::Error),
+    Query(ruma_serde::urlencoded::de::Error),
     Ident(ruma_identifiers::Error),
     // String <> Enum conversion failed. This can currently only happen in path
     // segment deserialization
@@ -239,8 +239,8 @@ impl From<serde_json::Error> for DeserializationError {
 }
 
 #[doc(hidden)]
-impl From<serde_urlencoded::de::Error> for DeserializationError {
-    fn from(err: serde_urlencoded::de::Error) -> Self {
+impl From<ruma_serde::urlencoded::de::Error> for DeserializationError {
+    fn from(err: ruma_serde::urlencoded::de::Error) -> Self {
         Self::Query(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,9 +200,9 @@ pub mod error;
 pub mod exports {
     pub use http;
     pub use percent_encoding;
+    pub use ruma_serde;
     pub use serde;
     pub use serde_json;
-    pub use serde_urlencoded;
 }
 
 use error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError};


### PR DESCRIPTION
 - adds `ruma-serde` as dependency
 - removes `serde_urlencoded` as dependency

edit(jplatte): fixes #49